### PR TITLE
FIX: #66 Possível duplicata durante cadastro de novas bolsas

### DIFF
--- a/db/migrations/20260311_create_cbos.sql
+++ b/db/migrations/20260311_create_cbos.sql
@@ -1,4 +1,4 @@
-CREATE TABLE pesquisa.linhas_pesquisa (
+CREATE TABLE pesquisa.cbos (
     id SERIAL,
     descricao VARCHAR (100),
     PRIMARY KEY (id)

--- a/db/migrations/20260311_create_table_bolsas_produtividade_cnpq.sql
+++ b/db/migrations/20260311_create_table_bolsas_produtividade_cnpq.sql
@@ -1,0 +1,5 @@
+CREATE TABLE pesquisa.bolsas_produtividade_cnpq(
+    id SERIAL,
+    descricao VARCHAR (10),
+    PRIMARY KEY (id)
+);

--- a/db/migrations/20260311_create_table_formacoes_academicas.sql
+++ b/db/migrations/20260311_create_table_formacoes_academicas.sql
@@ -1,0 +1,5 @@
+CREATE TABLE pesquisa.formacoes_academicas(
+    id SERIAL,
+    nome VARCHAR (50),
+    PRIMARY KEY (id)
+);

--- a/db/migrations/20260311_create_table_instituicoes.sql
+++ b/db/migrations/20260311_create_table_instituicoes.sql
@@ -1,0 +1,5 @@
+CREATE TABLE pesquisa.instituicoes(
+    id SERIAL,
+    nome VARCHAR (100),
+    PRIMARY KEY (id)
+);

--- a/db/migrations/20260311_create_table_niveis_formacao.sql
+++ b/db/migrations/20260311_create_table_niveis_formacao.sql
@@ -1,4 +1,4 @@
-CREATE TABLE pesquisa.linhas_pesquisa (
+CREATE TABLE pesquisa.niveis_formacao(
     id SERIAL,
     descricao VARCHAR (100),
     PRIMARY KEY (id)

--- a/db/migrations/20260311_create_table_orgaos_financiadores.sql
+++ b/db/migrations/20260311_create_table_orgaos_financiadores.sql
@@ -1,4 +1,4 @@
-CREATE TABLE pesquisa.linhas_pesquisa (
+CREATE TABLE pesquisa.orgaos_financiadores(
     id SERIAL,
     descricao VARCHAR (100),
     PRIMARY KEY (id)

--- a/db/migrations/20260311_create_table_programas_pos_graduacao.sql
+++ b/db/migrations/20260311_create_table_programas_pos_graduacao.sql
@@ -1,4 +1,4 @@
-CREATE TABLE pesquisa.linhas_pesquisa (
+CREATE TABLE pesquisa.programas_pos_graduacao(
     id SERIAL,
     descricao VARCHAR (100),
     PRIMARY KEY (id)

--- a/db/migrations/20260311_create_table_status_projeto.sql
+++ b/db/migrations/20260311_create_table_status_projeto.sql
@@ -1,4 +1,4 @@
-CREATE TABLE pesquisa.linhas_pesquisa (
+CREATE TABLE pesquisa.status_projeto(
     id SERIAL,
     descricao VARCHAR (100),
     PRIMARY KEY (id)

--- a/src/main/java/net/ebserh/hctm/controller/pesquisa/BolsasProdutividadeCnpqController.java
+++ b/src/main/java/net/ebserh/hctm/controller/pesquisa/BolsasProdutividadeCnpqController.java
@@ -5,7 +5,6 @@ import jakarta.faces.view.ViewScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import net.ebserh.hctm.model.pesquisa.BolsaProdutividadeCnpq;
-//import net.ebserh.hctm.service.pesquisa.PesquisasService;
 import net.ebserh.hctm.service.pesquisa.BolsasProdutividadeService;
 import net.ebserh.hctm.util.FacesUtils;
 import org.primefaces.PrimeFaces;
@@ -26,8 +25,6 @@ public class BolsasProdutividadeCnpqController implements Serializable {
     private BolsasProdutividadeService bolsasProdutividadeService;
 
     private List<BolsaProdutividadeCnpq> bolsas = new ArrayList<>();
-
-    private Boolean adicionar = true;
 
     private BolsaProdutividadeCnpq bolsaProdutividadeCnpq;
 
@@ -50,7 +47,6 @@ public class BolsasProdutividadeCnpqController implements Serializable {
             FacesUtils.showError("É necessário selecionar um registro para edição.");
             return;
         }
-        adicionar = false;
         this.bolsaProdutividadeCnpq = bolsaProdutividadeCnpq;
         PrimeFaces.current().executeScript("PF('dialogBolsaProdutividade').show()");
     }
@@ -67,8 +63,7 @@ public class BolsasProdutividadeCnpqController implements Serializable {
             PrimeFaces.current().executeScript("PF('dialogBolsaProdutividade').hide()");
             FacesUtils.showInfo("Dados salvos com sucesso!");
         } catch (Exception e) {
-            bolsas = bolsasProdutividadeService.buscaBolsas();
-            FacesUtils.processaExcecao(e, "Ocorreu um erro ao salvar os dados.");
+            FacesUtils.processaExcecao(e, "Ocorreu um erro ao salvar os a bolsa.");
         }
     }
 
@@ -87,6 +82,5 @@ public class BolsasProdutividadeCnpqController implements Serializable {
     public void setBolsaProdutividadeCnpq(BolsaProdutividadeCnpq bolsaProdutividadeCnpq) {
         this.bolsaProdutividadeCnpq = bolsaProdutividadeCnpq;
     }
-
 
 }

--- a/src/main/java/net/ebserh/hctm/controller/pesquisa/CbosController.java
+++ b/src/main/java/net/ebserh/hctm/controller/pesquisa/CbosController.java
@@ -60,7 +60,7 @@ public class CbosController implements Serializable {
             PrimeFaces.current().executeScript("PF('dialogCbo').hide()");
             FacesUtils.showInfo("Dados salvos com sucesso!");
         } catch (Exception e) {
-            FacesUtils.processaExcecao(e, "Ocorreu um erro ao salvar os dados.");
+            FacesUtils.processaExcecao(e, "Ocorreu um erro ao salvar o cbo.");
         }
     }
 

--- a/src/main/java/net/ebserh/hctm/controller/pesquisa/FormacoesAcademicasController.java
+++ b/src/main/java/net/ebserh/hctm/controller/pesquisa/FormacoesAcademicasController.java
@@ -4,8 +4,6 @@ import jakarta.annotation.PostConstruct;
 import jakarta.faces.view.ViewScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
-//import net.ebserh.hctm.model.pesquisa.FormacaoAcademica;
-//import net.ebserh.hctm.service.pesquisa.PesquisasService;
 import net.ebserh.hctm.model.pesquisa.FormacaoAcademica;
 import net.ebserh.hctm.service.pesquisa.FormacoesAcademicasService;
 import net.ebserh.hctm.util.FacesUtils;

--- a/src/main/java/net/ebserh/hctm/controller/pesquisa/LinhasPesquisaController.java
+++ b/src/main/java/net/ebserh/hctm/controller/pesquisa/LinhasPesquisaController.java
@@ -5,8 +5,7 @@ import jakarta.faces.view.ViewScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import net.ebserh.hctm.model.pesquisa.LinhaPesquisa;
-//import net.ebserh.hctm.model.pesquisa.NivelFormacao;
-import net.ebserh.hctm.service.pesquisa.PesquisasService;
+import net.ebserh.hctm.service.pesquisa.LinhasPesquisaService;
 import net.ebserh.hctm.util.FacesUtils;
 import org.primefaces.PrimeFaces;
 
@@ -16,16 +15,14 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-
 @Named
 @ViewScoped
 public class LinhasPesquisaController implements Serializable {
 
     private static final Logger LOGGER = Logger.getAnonymousLogger();
-    
 
     @Inject
-    private PesquisasService pesquisasService;
+    private LinhasPesquisaService linhasPesquisaService;
 
     private List<LinhaPesquisa> linhasPesquisa = new ArrayList<>();
 
@@ -34,7 +31,7 @@ public class LinhasPesquisaController implements Serializable {
     @PostConstruct
     public void init() {
         try {
-            linhasPesquisa = pesquisasService.buscaLinhasPesquisa();
+            linhasPesquisa = linhasPesquisaService.buscaLinhasPesquisa();
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
         }
@@ -62,8 +59,8 @@ public class LinhasPesquisaController implements Serializable {
         }
 
         try {
-            pesquisasService.salvaLinhaPesquisa(linhaPesquisa);
-            linhasPesquisa = pesquisasService.buscaLinhasPesquisa();
+            linhasPesquisaService.salvaLinhaPesquisa(linhaPesquisa);
+            linhasPesquisa = linhasPesquisaService.buscaLinhasPesquisa();
             PrimeFaces.current().executeScript("PF('dialogLinhaPesquisa').hide()");
             FacesUtils.showInfo("Dados salvos com sucesso!");
         } catch (Exception e) {

--- a/src/main/java/net/ebserh/hctm/controller/pesquisa/NiveisFormacaoController.java
+++ b/src/main/java/net/ebserh/hctm/controller/pesquisa/NiveisFormacaoController.java
@@ -4,8 +4,6 @@ import jakarta.annotation.PostConstruct;
 import jakarta.faces.view.ViewScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
-//import net.ebserh.hctm.model.pesquisa.NivelFormacao;
-//import net.ebserh.hctm.service.pesquisa.PesquisasService;
 import net.ebserh.hctm.model.pesquisa.NivelFormacao;
 import net.ebserh.hctm.service.pesquisa.NiveisFormacaoService;
 import net.ebserh.hctm.util.FacesUtils;

--- a/src/main/java/net/ebserh/hctm/controller/pesquisa/OrgaosFinanciadoresController.java
+++ b/src/main/java/net/ebserh/hctm/controller/pesquisa/OrgaosFinanciadoresController.java
@@ -4,7 +4,6 @@ import jakarta.annotation.PostConstruct;
 import jakarta.faces.view.ViewScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
-import jakarta.validation.constraints.Positive;
 import net.ebserh.hctm.model.pesquisa.OrgaoFinanciador;
 import net.ebserh.hctm.service.pesquisa.OrgaosFinanciadoresService;
 import net.ebserh.hctm.util.FacesUtils;
@@ -62,7 +61,7 @@ public class OrgaosFinanciadoresController implements Serializable {
             PrimeFaces.current().executeScript("PF('dialogOrgaoFinanciador').hide()");
             FacesUtils.showInfo("Dados salvos com sucesso!");
         } catch (Exception e) {
-            FacesUtils.processaExcecao(e, "Ocorreu um erro ao salvar os dados!");
+            FacesUtils.processaExcecao(e, "Ocorreu um erro ao salvar o orgao financiador!");
         }
     }
 

--- a/src/main/java/net/ebserh/hctm/controller/pesquisa/ProgramasPosGraduacaoController.java
+++ b/src/main/java/net/ebserh/hctm/controller/pesquisa/ProgramasPosGraduacaoController.java
@@ -4,10 +4,8 @@ import jakarta.annotation.PostConstruct;
 import jakarta.faces.view.ViewScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
-//import net.ebserh.hctm.model.pesquisa.ProgramaPosGraduacao;
-//import net.ebserh.hctm.service.pesquisa.PesquisasService;
 import net.ebserh.hctm.model.pesquisa.ProgramaPosGraduacao;
-import net.ebserh.hctm.service.pesquisa.PesquisasService;
+import net.ebserh.hctm.service.pesquisa.ProgramaPosGraduacaoService;
 import net.ebserh.hctm.util.FacesUtils;
 import org.primefaces.PrimeFaces;
 
@@ -24,7 +22,7 @@ public class ProgramasPosGraduacaoController implements Serializable {
     private final static Logger LOGGER = Logger.getAnonymousLogger();
 
     @Inject
-    private PesquisasService pesquisasService;
+    private ProgramaPosGraduacaoService programaPosGraduacaoService;
 
     private List<ProgramaPosGraduacao> programasPosGraduacao = new ArrayList<>();
 
@@ -33,7 +31,7 @@ public class ProgramasPosGraduacaoController implements Serializable {
     @PostConstruct
     public void init() {
         try {
-            programasPosGraduacao = pesquisasService.buscaProgramasPosGraduacao();
+            programasPosGraduacao = programaPosGraduacaoService.buscaProgramasPosGraduacao();
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
         }
@@ -56,13 +54,13 @@ public class ProgramasPosGraduacaoController implements Serializable {
 
     public void salva() {
         if (programaPosGraduacao == null) {
-            FacesUtils.showError("É necessário informar os dados do nível de formação.");
+            FacesUtils.showError("É necessário informar os dados do programa de pós graduação.");
             return;
         }
 
         try {
-            pesquisasService.salvaProgramaPosGraduacao(programaPosGraduacao);
-            programasPosGraduacao = pesquisasService.buscaProgramasPosGraduacao();
+            programaPosGraduacaoService.salvaProgramaPosGraduacao(programaPosGraduacao);
+            programasPosGraduacao = programaPosGraduacaoService.buscaProgramasPosGraduacao();
             PrimeFaces.current().executeScript("PF('dialogProgramaPosGraduacao').hide()");
             FacesUtils.showInfo("Programa de pós graduação salvo com sucesso!");
         } catch (Exception e) {

--- a/src/main/java/net/ebserh/hctm/controller/pesquisa/StatusProjetoController.java
+++ b/src/main/java/net/ebserh/hctm/controller/pesquisa/StatusProjetoController.java
@@ -22,7 +22,6 @@ public class StatusProjetoController implements Serializable {
     private static final Logger LOGGER = Logger.getAnonymousLogger();
 
     @Inject
-    //private Boolean adicionar = true;
     private StatusProjetoService statusProjetoService;
 
     private List<StatusProjeto> status = new ArrayList<>();
@@ -66,7 +65,7 @@ public class StatusProjetoController implements Serializable {
             PrimeFaces.current().executeScript("PF('dialogStatusProjeto').hide()");
             FacesUtils.showInfo("Dados salvos com sucesso!");
         }catch(Exception e){
-            FacesUtils.processaExcecao(e, "Ocorreu um erro ao salvar os dados.");
+            FacesUtils.processaExcecao(e, "Ocorreu um erro ao salvar o status de projeto");
         }
     }
 

--- a/src/main/java/net/ebserh/hctm/model/pesquisa/BolsaProdutividadeCnpq.java
+++ b/src/main/java/net/ebserh/hctm/model/pesquisa/BolsaProdutividadeCnpq.java
@@ -21,7 +21,8 @@ SELECT
 FROM
     BolsaProdutividadeCnpq b
 WHERE
-    b.descricao = :descricao""")
+    function('TRANSLATE', function('UPPER', b.descricao),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')
+    = function('TRANSLATE', function('UPPER', :descricao),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')""")
 public class BolsaProdutividadeCnpq extends AbstractEntity {
 
     @Size(max = 10)

--- a/src/main/java/net/ebserh/hctm/model/pesquisa/Cbo.java
+++ b/src/main/java/net/ebserh/hctm/model/pesquisa/Cbo.java
@@ -3,8 +3,6 @@ package net.ebserh.hctm.model.pesquisa;
 import jakarta.persistence.Entity;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import net.ebserh.hctm.model.util.AbstractEntity;
 
@@ -17,9 +15,17 @@ FROM
     Cbo c
 ORDER BY
     c.descricao""")
+@NamedQuery(name = "Cbo.findByDescricao", query = """
+SELECT
+    c
+FROM
+    Cbo c
+WHERE
+    function('TRANSLATE', function('UPPER', c.descricao),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')
+    = function('TRANSLATE', function('UPPER', :descricao),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')""")
 public class Cbo extends AbstractEntity {
 
-    @Size(max = 200)
+    @Size(max = 100)
     private String descricao;
 
     public String getDescricao() {

--- a/src/main/java/net/ebserh/hctm/model/pesquisa/FonteFinanciadora.java
+++ b/src/main/java/net/ebserh/hctm/model/pesquisa/FonteFinanciadora.java
@@ -21,7 +21,8 @@ SELECT
 FROM
     FonteFinanciadora f
 WHERE
-    UPPER(f.descricao) = :descricao""")
+    function('TRANSLATE', function('UPPER', f.descricao),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')
+    = function('TRANSLATE', function('UPPER', :descricao),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')""")
 public class FonteFinanciadora extends AbstractEntity {
 
     @Size(max = 100)

--- a/src/main/java/net/ebserh/hctm/model/pesquisa/FormacaoAcademica.java
+++ b/src/main/java/net/ebserh/hctm/model/pesquisa/FormacaoAcademica.java
@@ -21,7 +21,8 @@ SELECT
 FROM
     FormacaoAcademica f
 WHERE
-    f.nome = :nome""")
+    function('TRANSLATE', function('UPPER', f.nome),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')
+    = function('TRANSLATE', function('UPPER', :nome),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')""")
 public class FormacaoAcademica extends AbstractEntity {
 
     @Size(max = 50)

--- a/src/main/java/net/ebserh/hctm/model/pesquisa/Instituicao.java
+++ b/src/main/java/net/ebserh/hctm/model/pesquisa/Instituicao.java
@@ -21,7 +21,8 @@ SELECT
 FROM
     Instituicao i
 WHERE
-    i.nome = :nome""")
+    function('TRANSLATE', function('UPPER', i.nome),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')
+    = function('TRANSLATE', function('UPPER', :nome),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')""")
 public class Instituicao extends AbstractEntity {
 
     @Size(max = 100)

--- a/src/main/java/net/ebserh/hctm/model/pesquisa/LinhaPesquisa.java
+++ b/src/main/java/net/ebserh/hctm/model/pesquisa/LinhaPesquisa.java
@@ -22,7 +22,8 @@ SELECT
 FROM
     LinhaPesquisa l
 WHERE
-    UPPER(l.descricao) = :descricao""")
+    function('TRANSLATE', function('UPPER', l.descricao),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')
+    = function('TRANSLATE', function('UPPER', :descricao),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')""")
 public class LinhaPesquisa extends AbstractEntity {
 
     @Size(max = 100)

--- a/src/main/java/net/ebserh/hctm/model/pesquisa/NivelFormacao.java
+++ b/src/main/java/net/ebserh/hctm/model/pesquisa/NivelFormacao.java
@@ -15,6 +15,14 @@ FROM
     NivelFormacao o
 ORDER BY
     o.descricao""")
+@NamedQuery(name = "NivelFormacao.findByDescricao", query = """
+SELECT
+    o
+FROM
+    NivelFormacao o
+WHERE
+    function('TRANSLATE', function('UPPER', o.descricao),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')
+    = function('TRANSLATE', function('UPPER', :descricao),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')""")
 public class NivelFormacao extends AbstractEntity {
 
     @Size(max = 100)

--- a/src/main/java/net/ebserh/hctm/model/pesquisa/OrgaoFinanciador.java
+++ b/src/main/java/net/ebserh/hctm/model/pesquisa/OrgaoFinanciador.java
@@ -15,6 +15,14 @@ FROM
     OrgaoFinanciador o
 ORDER BY
     o.descricao""")
+@NamedQuery(name = "OrgaoFinanciador.findByDescricao", query = """
+SELECT
+    o
+FROM
+    OrgaoFinanciador o
+WHERE
+    function('TRANSLATE', function('UPPER', o.descricao),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')
+    = function('TRANSLATE', function('UPPER', :descricao),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')""")
 public class OrgaoFinanciador extends AbstractEntity {
 
     @Size(max = 100)

--- a/src/main/java/net/ebserh/hctm/model/pesquisa/ProgramaPosGraduacao.java
+++ b/src/main/java/net/ebserh/hctm/model/pesquisa/ProgramaPosGraduacao.java
@@ -8,10 +8,21 @@ import net.ebserh.hctm.model.util.AbstractEntity;
 
 @Entity
 @Table(schema = "pesquisa", name = "programas_pos_graduacao")
-@NamedQuery(name = "ProgramaPosGraduacao.findAll",
-        query = "SELECT p "
-                + "FROM ProgramaPosGraduacao p "
-                + "ORDER BY p.descricao")
+@NamedQuery(name = "ProgramaPosGraduacao.findAll", query = """
+SELECT
+    p
+FROM
+    ProgramaPosGraduacao p
+ORDER BY
+    p.descricao""")
+@NamedQuery(name = "ProgramaPosGraduacao.findByDescricao", query = """
+SELECT
+    p
+FROM
+    ProgramaPosGraduacao p
+WHERE
+    function('TRANSLATE', function('UPPER', p.descricao),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')
+    = function('TRANSLATE', function('UPPER', :descricao),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')""")
 public class ProgramaPosGraduacao extends AbstractEntity {
 
     @Size(max = 100)

--- a/src/main/java/net/ebserh/hctm/model/pesquisa/StatusProjeto.java
+++ b/src/main/java/net/ebserh/hctm/model/pesquisa/StatusProjeto.java
@@ -15,6 +15,14 @@ FROM
     StatusProjeto s
 ORDER BY
     s.descricao""")
+@NamedQuery(name = "StatusProjeto.findByDescricao", query = """
+SELECT
+    s
+FROM
+    StatusProjeto s
+WHERE
+    function('TRANSLATE', function('UPPER', s.descricao),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')
+    = function('TRANSLATE', function('UPPER', :descricao),'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ','AAAAAEEEEIIIIOOOOOUUUUC')""")
 public class StatusProjeto extends AbstractEntity {
 
     @Size(max = 100)

--- a/src/main/java/net/ebserh/hctm/service/pesquisa/BolsasProdutividadeService.java
+++ b/src/main/java/net/ebserh/hctm/service/pesquisa/BolsasProdutividadeService.java
@@ -1,14 +1,12 @@
 package net.ebserh.hctm.service.pesquisa;
 
 import jakarta.ejb.Stateless;
-import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.NonUniqueResultException;
 import jakarta.persistence.PersistenceContext;
 import net.ebserh.hctm.exception.CustomRuntimeException;
 import net.ebserh.hctm.model.pesquisa.BolsaProdutividadeCnpq;
-import net.ebserh.hctm.util.MockDb;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
@@ -43,6 +41,8 @@ public class BolsasProdutividadeService {
             throw new CustomRuntimeException("É necessário informar a descrição da bolsa.");
 
         try {
+            // Impede a entrada de string com espaço no inicio ou no fim
+            bolsaProdutividadeCnpq.setDescricao(StringUtils.trim(bolsaProdutividadeCnpq.getDescricao()));
             // Verifica duplicidade de registros
             try {
                 BolsaProdutividadeCnpq bolsaExistente = entityManager

--- a/src/main/java/net/ebserh/hctm/service/pesquisa/CbosService.java
+++ b/src/main/java/net/ebserh/hctm/service/pesquisa/CbosService.java
@@ -2,6 +2,8 @@ package net.ebserh.hctm.service.pesquisa;
 
 import jakarta.ejb.Stateless;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.NonUniqueResultException;
 import jakarta.persistence.PersistenceContext;
 import net.ebserh.hctm.exception.CustomRuntimeException;
 import net.ebserh.hctm.model.pesquisa.Cbo;
@@ -19,7 +21,6 @@ public class CbosService {
 
     @PersistenceContext
     private EntityManager entityManager;
-
 
     public List<Cbo> buscaCbos() {
         try {
@@ -40,10 +41,35 @@ public class CbosService {
             throw new CustomRuntimeException("É necessário informar a descrição da CBO.");
 
         try {
+            // Impede a entrada de string com espaço no inicio ou no fim
+            cbo.setDescricao(StringUtils.trim(cbo.getDescricao()));
+            // Verifica duplicidade de registros
+            try {
+                Cbo cboExistente = entityManager
+                        .createNamedQuery("Cbo.findByDescricao", Cbo.class)
+                        .setParameter("descricao", cbo.getDescricao().toUpperCase())
+                        .getSingleResult();
+
+                if (!cboExistente.getId().equals(cbo.getId()))
+                    throw new CustomRuntimeException("Já existe uma linha de pesquisas cadastrada com esta descrição.");
+            } catch (CustomRuntimeException e) {
+                throw e;
+            } catch (NoResultException e) {
+                // Ok, não há duplicidade
+            } catch (NonUniqueResultException e) {
+                throw new CustomRuntimeException(
+                        "Mais de uma linha de pesquisas previamente cadastrada com a descrição informada.");
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+                throw new CustomRuntimeException("Ocorreu um erro ao verificar a duplicidade de registros.");
+            }
+
             if (Objects.isNull(cbo.getId()))
                 entityManager.persist(cbo);
             else
                 entityManager.merge(cbo);
+        } catch (CustomRuntimeException e) {
+            throw e;
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
             throw new CustomRuntimeException("Ocorreu um erro ao salvar os dados da CBO.");

--- a/src/main/java/net/ebserh/hctm/service/pesquisa/FontesFinanciadorasService.java
+++ b/src/main/java/net/ebserh/hctm/service/pesquisa/FontesFinanciadorasService.java
@@ -41,6 +41,8 @@ public class FontesFinanciadorasService {
             throw new CustomRuntimeException("É necessário informar a descrição da fonte financiadora.");
 
         try {
+            // Impede entrada de string com espaco no inicio ou no fim
+            fonteFinanciadora.setDescricao(StringUtils.trim(fonteFinanciadora.getDescricao()));
             // Verifica duplicidade de registros
             try {
                 FonteFinanciadora fonteExistente = entityManager
@@ -70,7 +72,7 @@ public class FontesFinanciadorasService {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            throw new CustomRuntimeException("Ocorreu um erro ao salvar os dados da bolsa.");
+            throw new CustomRuntimeException("Ocorreu um erro ao salvar os dados da fonte financiadora.");
         }
     }
 

--- a/src/main/java/net/ebserh/hctm/service/pesquisa/FormacoesAcademicasService.java
+++ b/src/main/java/net/ebserh/hctm/service/pesquisa/FormacoesAcademicasService.java
@@ -41,6 +41,8 @@ public class FormacoesAcademicasService {
             throw new CustomRuntimeException("É necessário informar a descrição da formação.");
 
         try {
+            // Impede a entrada de string com espaço no inicio ou no fim
+            formacaoAcademica.setNome(StringUtils.trim(formacaoAcademica.getNome()));
             // Verifica duplicidade de registros
             try {
                 FormacaoAcademica formacaoExistente = entityManager
@@ -69,7 +71,7 @@ public class FormacoesAcademicasService {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            throw new CustomRuntimeException("Ocorreu um erro ao salvar os dados da bolsa.");
+            throw new CustomRuntimeException("Ocorreu um erro ao salvar os dados da formação.");
         }
     }
 

--- a/src/main/java/net/ebserh/hctm/service/pesquisa/InstituicoesService.java
+++ b/src/main/java/net/ebserh/hctm/service/pesquisa/InstituicoesService.java
@@ -29,18 +29,20 @@ public class InstituicoesService {
                     .getResultList();
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            throw new CustomRuntimeException("Ocorreu um erro ao buscar as formações acadêmicas.");
+            throw new CustomRuntimeException("Ocorreu um erro ao buscar as instituições.");
         }
     }
 
     public void salvaInstituicao(Instituicao instituicao) {
         if (Objects.isNull(instituicao))
-            throw new CustomRuntimeException("É necessário informar os dados da instituicao.");
+            throw new CustomRuntimeException("É necessário informar os dados da instituição.");
 
         if (StringUtils.isBlank(instituicao.getNome()))
-            throw new CustomRuntimeException("É necessário informar a descrição da instituicao.");
+            throw new CustomRuntimeException("É necessário informar a descrição da instituição.");
 
         try {
+            // Impede a entrada de string com espaço no inicio ou no fim
+            instituicao.setNome(StringUtils.trim(instituicao.getNome()));
             // Verifica duplicidade de registros
             try {
                 Instituicao instituicaoExistente = entityManager
@@ -49,13 +51,13 @@ public class InstituicoesService {
                         .getSingleResult();
 
                 if (!instituicaoExistente.getId().equals(instituicao.getId()))
-                    throw new CustomRuntimeException("Já existe uma instituicao cadastrada com este nome.");
+                    throw new CustomRuntimeException("Já existe uma instituição cadastrada com este nome.");
             } catch (CustomRuntimeException e) {
                 throw e;
             } catch (NoResultException e) {
                 // Ok, não há duplicidade
             } catch (NonUniqueResultException e) {
-                throw new CustomRuntimeException("Mais de uma instituicao previamente cadastrada com o nome informado.");
+                throw new CustomRuntimeException("Mais de uma instituição previamente cadastrada com o nome informado.");
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);
                 throw new CustomRuntimeException("Ocorreu um erro ao verificar a duplicidade de registros.");
@@ -69,7 +71,7 @@ public class InstituicoesService {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            throw new CustomRuntimeException("Ocorreu um erro ao salvar os dados da instituicao.");
+            throw new CustomRuntimeException("Ocorreu um erro ao salvar os dados da instituição.");
         }
     }
 }

--- a/src/main/java/net/ebserh/hctm/service/pesquisa/LinhasPesquisaService.java
+++ b/src/main/java/net/ebserh/hctm/service/pesquisa/LinhasPesquisaService.java
@@ -6,7 +6,7 @@ import jakarta.persistence.NoResultException;
 import jakarta.persistence.NonUniqueResultException;
 import jakarta.persistence.PersistenceContext;
 import net.ebserh.hctm.exception.CustomRuntimeException;
-import net.ebserh.hctm.model.pesquisa.NivelFormacao;
+import net.ebserh.hctm.model.pesquisa.LinhaPesquisa;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
@@ -15,65 +15,65 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 @Stateless
-public class NiveisFormacaoService {
+public class LinhasPesquisaService {
 
     private static final Logger LOGGER = Logger.getAnonymousLogger();
 
     @PersistenceContext
     private EntityManager entityManager;
 
-    public List<NivelFormacao> buscaNiveis() {
+    public List<LinhaPesquisa> buscaLinhasPesquisa() {
         try {
             return entityManager
-                    .createNamedQuery("NivelFormacao.findAll", NivelFormacao.class)
+                    .createNamedQuery("LinhaPesquisa.findAll", LinhaPesquisa.class)
                     .getResultList();
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            throw new CustomRuntimeException("Erro na busca pelos níveis de formação!");
+            throw new CustomRuntimeException("Ocorreu um erro ao buscar as linhas de pesquisas.");
         }
     }
 
-    public void salvaNivelFormacao (NivelFormacao nivelFormacao) {
-        if (Objects.isNull(nivelFormacao))
-            throw new CustomRuntimeException("É necessário informar os dados do nível de formação!");
+    public void salvaLinhaPesquisa(LinhaPesquisa linhaPesquisa) {
+        if (Objects.isNull(linhaPesquisa))
+            throw new CustomRuntimeException("É necessário informar os dados da linha de pesquisas.");
 
-        if (StringUtils.isBlank(nivelFormacao.getNivel()))
-            throw new CustomRuntimeException("É necessário informar o nome do nível de formação!");
+        if (StringUtils.isBlank(linhaPesquisa.getDescricao()))
+            throw new CustomRuntimeException("É necessário informar a descrição da linha de pesquisas.");
 
         try {
-
             // Impede a entrada de string com espaço no inicio ou no fim
-            nivelFormacao.setNivel(StringUtils.trim(nivelFormacao.getNivel()));
+            linhaPesquisa.setDescricao(StringUtils.trim(linhaPesquisa.getDescricao()));
             // Verifica duplicidade de registros
             try {
-                NivelFormacao nivelFormacaoExistente = entityManager
-                        .createNamedQuery("NivelFormacao.findByDescricao", NivelFormacao.class)
-                        .setParameter("descricao", nivelFormacao.getNivel().toUpperCase())
+                LinhaPesquisa linhaPesquisaExistente = entityManager
+                        .createNamedQuery("LinhaPesquisa.findByDescricao", LinhaPesquisa.class)
+                        .setParameter("descricao", linhaPesquisa.getDescricao().toUpperCase())
                         .getSingleResult();
 
-                if (!nivelFormacaoExistente.getId().equals(nivelFormacao.getId()))
-                    throw new CustomRuntimeException("Já existe um nível de formação cadastrado com esta descrição.");
+                if (!linhaPesquisaExistente.getId().equals(linhaPesquisa.getId()))
+                    throw new CustomRuntimeException("Já existe uma linha de pesquisas cadastrada com esta descrição.");
             } catch (CustomRuntimeException e) {
                 throw e;
             } catch (NoResultException e) {
                 // Ok, não há duplicidade
             } catch (NonUniqueResultException e) {
                 throw new CustomRuntimeException(
-                        "Mais de um nível de formação previamente cadastrada com a descrição informada.");
+                        "Mais de uma linha de pesquisas previamente cadastrada com a descrição informada.");
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);
                 throw new CustomRuntimeException("Ocorreu um erro ao verificar a duplicidade de registros.");
             }
-            if (Objects.isNull(nivelFormacao.getId()))
-                entityManager.persist(nivelFormacao);
-            else
-                entityManager.merge(nivelFormacao);
 
+            if (Objects.isNull(linhaPesquisa.getId()))
+                entityManager.persist(linhaPesquisa);
+            else
+                entityManager.merge(linhaPesquisa);
         } catch (CustomRuntimeException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            throw new CustomRuntimeException("Erro ao salvar nível de formação!");
+            throw new CustomRuntimeException("Ocorreu um erro ao salvar os dados da linha de pesquisas.");
         }
     }
+
 }

--- a/src/main/java/net/ebserh/hctm/service/pesquisa/OrgaosFinanciadoresService.java
+++ b/src/main/java/net/ebserh/hctm/service/pesquisa/OrgaosFinanciadoresService.java
@@ -1,12 +1,12 @@
 package net.ebserh.hctm.service.pesquisa;
 
 import jakarta.ejb.Stateless;
-import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.NonUniqueResultException;
 import jakarta.persistence.PersistenceContext;
 import net.ebserh.hctm.exception.CustomRuntimeException;
 import net.ebserh.hctm.model.pesquisa.OrgaoFinanciador;
-import net.ebserh.hctm.util.MockDb;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
@@ -41,10 +41,36 @@ public class OrgaosFinanciadoresService {
             throw new CustomRuntimeException("É necessário informar o nome do órgão financiador!");
 
         try {
+            // Impede a entrada de string com espaço no inicio ou no fim
+            orgaoFinanciador.setDescricao(StringUtils.trim(orgaoFinanciador.getDescricao()));
+            // Verifica duplicidade de registros
+            try {
+                OrgaoFinanciador orgaoFinanciadorExistente = entityManager
+                        .createNamedQuery("OrgaoFinanciador.findByDescricao", OrgaoFinanciador.class)
+                        .setParameter("descricao", orgaoFinanciador.getDescricao().toUpperCase())
+                        .getSingleResult();
+
+                if (!orgaoFinanciadorExistente.getId().equals(orgaoFinanciador.getId()))
+                    throw new CustomRuntimeException("Já existe uma linha de pesquisas cadastrada com esta descrição.");
+            } catch (CustomRuntimeException e) {
+                throw e;
+            } catch (NoResultException e) {
+                // Ok, não há duplicidade
+            } catch (NonUniqueResultException e) {
+                throw new CustomRuntimeException(
+                        "Mais de uma linha de pesquisas previamente cadastrada com a descrição informada.");
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+                throw new CustomRuntimeException("Ocorreu um erro ao verificar a duplicidade de registros.");
+            }
+
             if (Objects.isNull(orgaoFinanciador.getId()))
                 entityManager.persist(orgaoFinanciador);
             else
                 entityManager.merge(orgaoFinanciador);
+        } catch (CustomRuntimeException e) {
+            throw e;
+
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
             throw new CustomRuntimeException("Erro ao salvar os dados do órgão financiador!");

--- a/src/main/java/net/ebserh/hctm/service/pesquisa/PesquisasService.java
+++ b/src/main/java/net/ebserh/hctm/service/pesquisa/PesquisasService.java
@@ -22,52 +22,106 @@ public class PesquisasService {
     @PersistenceContext
     private EntityManager entityManager;
 
-    public List<BolsaProdutividadeCnpq> buscaBolsas() {
+ public List<BolsaProdutividadeCnpq> buscaBolsas() {
         try {
             return entityManager
                     .createNamedQuery("BolsaProdutividadeCnpq.findAll", BolsaProdutividadeCnpq.class)
                     .getResultList();
-        } catch (Exception  e) {
+        } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            throw new CustomRuntimeException("Ocorreu um erro ao buscar as bolsas.");
+            throw new CustomRuntimeException("Ocorreu um erro ao buscar as bolsas cadastradas.");
         }
     }
 
     public void salvaBolsaProdutividade(BolsaProdutividadeCnpq bolsaProdutividadeCnpq) {
-        if (bolsaProdutividadeCnpq == null)
+        if (Objects.isNull(bolsaProdutividadeCnpq))
             throw new CustomRuntimeException("É necessário informar os dados da bolsa.");
 
+        if (StringUtils.isBlank(bolsaProdutividadeCnpq.getDescricao()))
+            throw new CustomRuntimeException("É necessário informar a descrição da bolsa.");
+
         try {
-            if (bolsaProdutividadeCnpq.getId() == null)
+            // Impede a entrada de string com espaço no inicio ou no fim
+            bolsaProdutividadeCnpq.setDescricao(StringUtils.trim(bolsaProdutividadeCnpq.getDescricao()));
+            // Verifica duplicidade de registros
+            try {
+                BolsaProdutividadeCnpq bolsaExistente = entityManager
+                        .createNamedQuery("BolsaProdutividadeCnpq.findByDescricao", BolsaProdutividadeCnpq.class)
+                        .setParameter("descricao", bolsaProdutividadeCnpq.getDescricao())
+                        .getSingleResult();
+
+                if (!bolsaExistente.getId().equals(bolsaProdutividadeCnpq.getId()))
+                    throw new CustomRuntimeException("Já existe uma bolsa cadastrada com esta descrição.");
+            } catch (CustomRuntimeException e) {
+                throw e;
+            } catch (NoResultException e) {
+                // Ok, não há duplicidade
+            } catch (NonUniqueResultException e) {
+                throw new CustomRuntimeException("Mais de uma bolsa previamente cadastrada com a descrição informada.");
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+                throw new CustomRuntimeException("Ocorreu um erro ao verificar a duplicidade de registros.");
+            }
+
+            if (Objects.isNull(bolsaProdutividadeCnpq.getId()))
                 entityManager.persist(bolsaProdutividadeCnpq);
             else
                 entityManager.merge(bolsaProdutividadeCnpq);
+        } catch (CustomRuntimeException e) {
+            throw e;
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
             throw new CustomRuntimeException("Ocorreu um erro ao salvar os dados da bolsa.");
         }
     }
 
-    public List<FormacaoAcademica> buscaFormacoesAcademicas() {
+    public List<FormacaoAcademica> buscaFormacoes() {
         try {
             return entityManager
                     .createNamedQuery("FormacaoAcademica.findAll", FormacaoAcademica.class)
                     .getResultList();
-        } catch (Exception  e) {
+        } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            throw new CustomRuntimeException("Ocorreu um erro ao buscar as formações.");
+            throw new CustomRuntimeException("Ocorreu um erro ao buscar as formações acadêmicas.");
         }
     }
 
     public void salvaFormacaoAcademica(FormacaoAcademica formacaoAcademica) {
-        if (formacaoAcademica == null)
+        if (Objects.isNull(formacaoAcademica))
             throw new CustomRuntimeException("É necessário informar os dados da formação.");
 
+        if (StringUtils.isBlank(formacaoAcademica.getNome()))
+            throw new CustomRuntimeException("É necessário informar a descrição da formação.");
+
         try {
-            if (formacaoAcademica.getId() == null)
+            // Impede a entrada de string com espaço no inicio ou no fim
+            formacaoAcademica.setNome(StringUtils.trim(formacaoAcademica.getNome()));
+            // Verifica duplicidade de registros
+            try {
+                FormacaoAcademica formacaoExistente = entityManager
+                        .createNamedQuery("FormacaoAcademica.findByNome", FormacaoAcademica.class)
+                        .setParameter("nome", formacaoAcademica.getNome())
+                        .getSingleResult();
+
+                if (!formacaoExistente.getId().equals(formacaoAcademica.getId()))
+                    throw new CustomRuntimeException("Já existe uma formação cadastrada com este nome.");
+            } catch (CustomRuntimeException e) {
+                throw e;
+            } catch (NoResultException e) {
+                // Ok, não há duplicidade
+            } catch (NonUniqueResultException e) {
+                throw new CustomRuntimeException("Mais de uma formação previamente cadastrada com a descrição informada.");
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+                throw new CustomRuntimeException("Ocorreu um erro ao verificar a duplicidade de registros.");
+            }
+
+            if (Objects.isNull(formacaoAcademica.getId()))
                 entityManager.persist(formacaoAcademica);
             else
                 entityManager.merge(formacaoAcademica);
+        } catch (CustomRuntimeException e) {
+            throw e;
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
             throw new CustomRuntimeException("Ocorreu um erro ao salvar os dados da formação.");
@@ -79,21 +133,48 @@ public class PesquisasService {
             return entityManager
                     .createNamedQuery("Instituicao.findAll", Instituicao.class)
                     .getResultList();
-        } catch (Exception  e) {
+        } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
             throw new CustomRuntimeException("Ocorreu um erro ao buscar as instituições.");
         }
     }
 
     public void salvaInstituicao(Instituicao instituicao) {
-        if (instituicao == null)
+        if (Objects.isNull(instituicao))
             throw new CustomRuntimeException("É necessário informar os dados da instituição.");
 
+        if (StringUtils.isBlank(instituicao.getNome()))
+            throw new CustomRuntimeException("É necessário informar a descrição da instituição.");
+
         try {
-            if (instituicao.getId() == null)
+            // Impede a entrada de string com espaço no inicio ou no fim
+            instituicao.setNome(StringUtils.trim(instituicao.getNome()));
+            // Verifica duplicidade de registros
+            try {
+                Instituicao instituicaoExistente = entityManager
+                        .createNamedQuery("Instituicao.findByNome", Instituicao.class)
+                        .setParameter("nome", instituicao.getNome())
+                        .getSingleResult();
+
+                if (!instituicaoExistente.getId().equals(instituicao.getId()))
+                    throw new CustomRuntimeException("Já existe uma instituição cadastrada com este nome.");
+            } catch (CustomRuntimeException e) {
+                throw e;
+            } catch (NoResultException e) {
+                // Ok, não há duplicidade
+            } catch (NonUniqueResultException e) {
+                throw new CustomRuntimeException("Mais de uma instituição previamente cadastrada com o nome informado.");
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+                throw new CustomRuntimeException("Ocorreu um erro ao verificar a duplicidade de registros.");
+            }
+
+            if (Objects.isNull(instituicao.getId()))
                 entityManager.persist(instituicao);
             else
                 entityManager.merge(instituicao);
+        } catch (CustomRuntimeException e) {
+            throw e;
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
             throw new CustomRuntimeException("Ocorreu um erro ao salvar os dados da instituição.");
@@ -119,6 +200,8 @@ public class PesquisasService {
             throw new CustomRuntimeException("É necessário informar a descrição da linha de pesquisas.");
 
         try {
+            // Impede entrada de string com espaco no inicio ou no fim
+            linhaPesquisa.setDescricao(StringUtils.trim(linhaPesquisa.getDescricao()));
             // Verifica duplicidade de registros
             try {
                 LinhaPesquisa linhaPesquisaExistente = entityManager
@@ -152,41 +235,108 @@ public class PesquisasService {
         }
     }
 
-    public void salvaNivelFormacao(NivelFormacao nivelFormacao) {
-        if (nivelFormacao == null)
-            throw new CustomRuntimeException("É necessário informar os dados do nível de formação.");
+    public List<NivelFormacao> buscaNiveis() {
+            try {
+                return entityManager
+                        .createNamedQuery("NivelFormacao.findAll", NivelFormacao.class)
+                        .getResultList();
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+                throw new CustomRuntimeException("Erro na busca pelos níveis de formação!");
+            }
+        }
+
+    public void salvaNivelFormacao (NivelFormacao nivelFormacao) {
+        if (Objects.isNull(nivelFormacao))
+            throw new CustomRuntimeException("É necessário informar os dados do nível de formação!");
+
+        if (StringUtils.isBlank(nivelFormacao.getNivel()))
+            throw new CustomRuntimeException("É necessário informar o nome do nível de formação!");
 
         try {
-            if (nivelFormacao.getId() == null)
+            // Impede a entrada de string com espaço no inicio ou no fim
+            nivelFormacao.setNivel(StringUtils.trim(nivelFormacao.getNivel()));
+            // Verifica duplicidade de registros
+            try {
+                NivelFormacao nivelFormacaoExistente = entityManager
+                        .createNamedQuery("NivelFormacao.findByDescricao", NivelFormacao.class)
+                        .setParameter("descricao", nivelFormacao.getNivel().toUpperCase())
+                        .getSingleResult();
+
+                if (!nivelFormacaoExistente.getId().equals(nivelFormacao.getId()))
+                    throw new CustomRuntimeException("Já existe um nível de formação cadastrado com esta descrição.");
+            } catch (CustomRuntimeException e) {
+                throw e;
+            } catch (NoResultException e) {
+                // Ok, não há duplicidade
+            } catch (NonUniqueResultException e) {
+                throw new CustomRuntimeException(
+                        "Mais de um nível de formação previamente cadastrada com a descrição informada.");
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+                throw new CustomRuntimeException("Ocorreu um erro ao verificar a duplicidade de registros.");
+            }
+            if (Objects.isNull(nivelFormacao.getId()))
                 entityManager.persist(nivelFormacao);
             else
                 entityManager.merge(nivelFormacao);
+
+        } catch (CustomRuntimeException e) {
+            throw e;
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            throw new CustomRuntimeException("Ocorreu um erro ao salvar os dados do nível de formação.");
+            throw new CustomRuntimeException("Erro ao salvar nível de formação!");
         }
     }
 
-    public List<ProgramaPosGraduacao> buscaProgramasPosGraduacao() {
+public List<ProgramaPosGraduacao> buscaProgramasPosGraduacao() {
         try {
             return entityManager
                     .createNamedQuery("ProgramaPosGraduacao.findAll", ProgramaPosGraduacao.class)
                     .getResultList();
-        } catch (Exception  e) {
+        } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            throw new CustomRuntimeException("Ocorreu um erro ao buscar os programas de pós graduação.");
+            throw new CustomRuntimeException("Ocorreu um erro ao buscar o programa de pós graduação.");
         }
     }
 
     public void salvaProgramaPosGraduacao(ProgramaPosGraduacao programaPosGraduacao) {
-        if (programaPosGraduacao == null)
+        if (Objects.isNull(programaPosGraduacao))
             throw new CustomRuntimeException("É necessário informar os dados do programa de pós graduação.");
 
+        if (StringUtils.isBlank(programaPosGraduacao.getDescricao()))
+            throw new CustomRuntimeException("É necessário informar a descrição do programa de pós graduação.");
+
         try {
-            if (programaPosGraduacao.getId() == null)
+            // Impede entrada de string com espaco no inicio ou no fim
+            programaPosGraduacao.setDescricao(StringUtils.trim(programaPosGraduacao.getDescricao()));
+            // Verifica duplicidade de registros
+            try {
+                ProgramaPosGraduacao programaPosGraduacaoExistente = entityManager
+                        .createNamedQuery("ProgramaPosGraduacao.findByDescricao", ProgramaPosGraduacao.class)
+                        .setParameter("descricao", programaPosGraduacao.getDescricao().toUpperCase())
+                        .getSingleResult();
+
+                if (!programaPosGraduacaoExistente.getId().equals(programaPosGraduacao.getId()))
+                    throw new CustomRuntimeException("Já existe um programa de pós graduação cadastrado com esta descrição.");
+            } catch (CustomRuntimeException e) {
+                throw e;
+            } catch (NoResultException e) {
+                // Ok, não há duplicidade
+            } catch (NonUniqueResultException e) {
+                throw new CustomRuntimeException(
+                        "Mais de um programa de pós graduação previamente cadastrada com a descrição informada.");
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+                throw new CustomRuntimeException("Ocorreu um erro ao verificar a duplicidade de registros.");
+            }
+
+            if (Objects.isNull(programaPosGraduacao.getId()))
                 entityManager.persist(programaPosGraduacao);
             else
                 entityManager.merge(programaPosGraduacao);
+        } catch (CustomRuntimeException e) {
+            throw e;
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
             throw new CustomRuntimeException("Ocorreu um erro ao salvar os dados do programa de pós graduação.");

--- a/src/main/java/net/ebserh/hctm/service/pesquisa/ProgramaPosGraduacaoService.java
+++ b/src/main/java/net/ebserh/hctm/service/pesquisa/ProgramaPosGraduacaoService.java
@@ -1,0 +1,79 @@
+package net.ebserh.hctm.service.pesquisa;
+
+import jakarta.ejb.Stateless;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.NonUniqueResultException;
+import jakarta.persistence.PersistenceContext;
+import net.ebserh.hctm.exception.CustomRuntimeException;
+import net.ebserh.hctm.model.pesquisa.ProgramaPosGraduacao;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Stateless
+public class ProgramaPosGraduacaoService{
+
+    private static final Logger LOGGER = Logger.getAnonymousLogger();
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public List<ProgramaPosGraduacao> buscaProgramasPosGraduacao() {
+        try {
+            return entityManager
+                    .createNamedQuery("ProgramaPosGraduacao.findAll", ProgramaPosGraduacao.class)
+                    .getResultList();
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            throw new CustomRuntimeException("Ocorreu um erro ao buscar o programa de pós graduação.");
+        }
+    }
+
+    public void salvaProgramaPosGraduacao(ProgramaPosGraduacao programaPosGraduacao) {
+        if (Objects.isNull(programaPosGraduacao))
+            throw new CustomRuntimeException("É necessário informar os dados do programa de pós graduação.");
+
+        if (StringUtils.isBlank(programaPosGraduacao.getDescricao()))
+            throw new CustomRuntimeException("É necessário informar a descrição do programa de pós graduação.");
+
+        try {
+            // Impede entrada de string com espaco no inicio ou no fim
+            programaPosGraduacao.setDescricao(StringUtils.trim(programaPosGraduacao.getDescricao()));
+            // Verifica duplicidade de registros
+            try {
+                ProgramaPosGraduacao programaPosGraduacaoExistente = entityManager
+                        .createNamedQuery("ProgramaPosGraduacao.findByDescricao", ProgramaPosGraduacao.class)
+                        .setParameter("descricao", programaPosGraduacao.getDescricao().toUpperCase())
+                        .getSingleResult();
+
+                if (!programaPosGraduacaoExistente.getId().equals(programaPosGraduacao.getId()))
+                    throw new CustomRuntimeException("Já existe um programa de pós graduação cadastrado com esta descrição.");
+            } catch (CustomRuntimeException e) {
+                throw e;
+            } catch (NoResultException e) {
+                // Ok, não há duplicidade
+            } catch (NonUniqueResultException e) {
+                throw new CustomRuntimeException(
+                        "Mais de um programa de pós graduação previamente cadastrada com a descrição informada.");
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+                throw new CustomRuntimeException("Ocorreu um erro ao verificar a duplicidade de registros.");
+            }
+
+            if (Objects.isNull(programaPosGraduacao.getId()))
+                entityManager.persist(programaPosGraduacao);
+            else
+                entityManager.merge(programaPosGraduacao);
+        } catch (CustomRuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            throw new CustomRuntimeException("Ocorreu um erro ao salvar os dados do programa de pós graduação.");
+        }
+    }
+
+}

--- a/src/main/java/net/ebserh/hctm/service/pesquisa/StatusProjetoService.java
+++ b/src/main/java/net/ebserh/hctm/service/pesquisa/StatusProjetoService.java
@@ -1,12 +1,12 @@
 package net.ebserh.hctm.service.pesquisa;
 
 import jakarta.ejb.Stateless;
-//import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.NonUniqueResultException;
 import jakarta.persistence.PersistenceContext;
 import net.ebserh.hctm.exception.CustomRuntimeException;
 import net.ebserh.hctm.model.pesquisa.StatusProjeto;
-//import net.ebserh.hctm.util.MockDb;
 import org.apache.commons.lang3.StringUtils;
 import java.util.List;
 import java.util.Objects;
@@ -42,10 +42,35 @@ public class StatusProjetoService {
             throw new CustomRuntimeException("É necessário informar a descrição do status de projeto.");
         }
         try{
+            // Impede a entrada de string com espaço no inicio ou no fim
+            statusProjeto.setDescricao(StringUtils.trim(statusProjeto.getDescricao()));
+            // Verifica duplicidade de registros
+            try {
+                StatusProjeto statusProjetoExistente = entityManager
+                        .createNamedQuery("StatusProjeto.findByDescricao", StatusProjeto.class)
+                        .setParameter("descricao", statusProjeto.getDescricao().toUpperCase())
+                        .getSingleResult();
+
+                if (!statusProjetoExistente.getId().equals(statusProjeto.getId()))
+                    throw new CustomRuntimeException("Já existe um status cadastrado com esta descrição.");
+            } catch (CustomRuntimeException e) {
+                throw e;
+            } catch (NoResultException e) {
+                // Ok, não há duplicidade
+            } catch (NonUniqueResultException e) {
+                throw new CustomRuntimeException(
+                        "Mais de um status previamente cadastrada com a descrição informada.");
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+                throw new CustomRuntimeException("Ocorreu um erro ao verificar a duplicidade de registros.");
+            }
+        
             if (Objects.isNull(statusProjeto.getId()))
                 entityManager.persist(statusProjeto);
             else
                 entityManager.merge(statusProjeto);
+        } catch (CustomRuntimeException e) {
+            throw e;
         }catch(Exception e){
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
             throw new CustomRuntimeException("Ocorreu um erro ao salvar os status de projeto cadastrados.");

--- a/src/main/webapp/pesquisa/administracao/programas-pos-graduacao.xhtml
+++ b/src/main/webapp/pesquisa/administracao/programas-pos-graduacao.xhtml
@@ -5,7 +5,7 @@
 	xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
 
 	<ui:define name="content">
-		<h2>Níveis de Formação</h2>
+		<h2>Programas de Pós-graduação</h2>
 
 		<h:form id="formProgramasPosGraduacao">
 			<div class="ui-fluid formgrid grid">


### PR DESCRIPTION
Solução implementada:
- Remover "espaço" no inicio e no fim da string antes de salvar no banco, na camada de service.
- Utilizar a função Translate do sql para converter caracteres com acento para sem acento, durante a busca no banco.
- Houve alteração de muitas linhas e arquivos devido a resolução de problemas anteriores, como por exemplo a ausência do service de "Programas Pós-graduação" 